### PR TITLE
Changed github action permission to minimum necessary

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,6 @@
 name: Python testing
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,4 +1,6 @@
 name: Run application
+permissions:
+  contents: read
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
When running a github action, it creates a temporary token that has read & write access to everything in the repo.
It is best practices to reduce this to the minimum amount necessary.

All three current workflows only need read permission

closes #17