### PR TITLE
Rename PubMed Author Finder to Scholar Seek

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -67,7 +67,7 @@ jobs:
             - name: Run Script
               run: |
                 source .venv/bin/activate
-                python src/main.py -m ${{inputs.mode}} -e ${{inputs.email}} -n ${{inputs.searchnumber}} -s ${{inputs.sortby}} "${{inputs.search}}" >> $GITHUB_STEP_SUMMARY
+                python cli/main.py -m ${{inputs.mode}} -e ${{inputs.email}} -n ${{inputs.searchnumber}} -s ${{inputs.sortby}} "${{inputs.search}}" >> $GITHUB_STEP_SUMMARY
             
             
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# PubMed Author Finder
+# Scholar Seek
 
 **Know a topic? Pull up articles. Meet authors. Make contact.**
 
-PubMed Author Finder helps you quickly find research papers on any topic and gives you author contact info so you can reach out faster.
+Scholar Seek helps you quickly find research papers on any topic and gives you author contact info so you can reach out faster.
 
 ---
 
@@ -14,7 +14,7 @@ PubMed Author Finder helps you quickly find research papers on any topic and giv
 
 ## Using the GitHub Action
 
-You can interact with PubMed Author Finder directly from GitHub using the provided GitHub Action workflow. This is useful for running searches and retrieving results without setting up the app locally.
+You can interact with Scholar Seek directly from GitHub using the provided GitHub Action workflow. This is useful for running searches and retrieving results without setting up the app locally.
 
 ### How to Trigger
 
@@ -47,7 +47,7 @@ You can interact with PubMed Author Finder directly from GitHub using the provid
 
 ## How to Use the script
 
-Once downloaded, you can run `PubMedSearch` directly from your terminal.
+Once downloaded, you can run `Scholar Seek` directly from your terminal.
 
 **Basic search:**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Know a topic? Pull up articles. Meet authors. Make contact.**
 
-Scholar Seek helps you quickly find research papers on any topic and gives you author contact info so you can reach out faster.
+Scholar Seek will help you quickly find research papers on any topic and gives you author contact info so you can reach out faster.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "pubmed-author-finder"
-version = "0.1.0"
+name = "ScholarSeek"
+version = "0.2.0"
 description = "Find published researchers on pubmed"
 
 authors = [{name="Nitahi Escolar Bach", email="nitahieb@gmail.com"}]


### PR DESCRIPTION
Updated all instances of 'PubMed Author Finder' to 'Scholar Seek' in the README and other relevant files.